### PR TITLE
Handle zero total progress in metadata reading

### DIFF
--- a/src/tuneFinder.ts
+++ b/src/tuneFinder.ts
@@ -58,7 +58,11 @@ async function readMetadataForAllFiles(window: BrowserWindow, files: string[], g
             // tslint:disable-next-line: no-console
             console.log('*** Could not read metadata from ', files[index]);
         }
-        window.webContents.send('progress', Math.round((actualProgress / totalProgress) * 100));
+        const percent =
+            totalProgress === 0
+                ? 100
+                : Math.round((actualProgress / totalProgress) * 100);
+        window.webContents.send('progress', percent);
     }
     return all;
 }


### PR DESCRIPTION
## Summary
- Avoid divide-by-zero when computing progress
- Report 100% progress when no matching tunes remain

## Testing
- `npm run lint` *(fails: command "lint" does not exist)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a6337595b4832cbc84484cc1f436af