### PR TITLE
Fix hour rounding in time formatter

### DIFF
--- a/src/models/timeFormatter.ts
+++ b/src/models/timeFormatter.ts
@@ -1,7 +1,7 @@
 export function formatTime(seconds: number): string {
     // Hours, minutes and seconds
     if (!seconds) return '0:00';
-    const hrs = Math.round(seconds / 3600);
+    const hrs = Math.floor(seconds / 3600);
     const mins = Math.floor((seconds % 3600) / 60);
     const secs = Math.round(seconds % 60);
 

--- a/tests/timeFormatter.test.ts
+++ b/tests/timeFormatter.test.ts
@@ -1,0 +1,11 @@
+import assert from 'assert';
+import { formatTime } from '../src/models/timeFormatter';
+
+// Basic cases
+assert.strictEqual(formatTime(0), '0:00');
+assert.strictEqual(formatTime(59), '0:59');
+assert.strictEqual(formatTime(60), '1:00');
+assert.strictEqual(formatTime(3599), '59:59');
+assert.strictEqual(formatTime(3600), '1:00:00');
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- use floor to compute hours in `formatTime`
- add regression tests for time formatting

## Testing
- `npx ts-node --compiler-options '{"module":"commonjs"}' tests/timeFormatter.test.ts`
- `npm run lint` *(fails: command lint does not exist)*
- `npm test` *(fails: missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a58a597188832c8648257c24250ec6